### PR TITLE
docs: Fix typo in README and add Gameplay section (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dodge Object Game
+# Dodge Objects Game
 
 <a href="https://winter-of-open-source.vercel.app/"><img src="assets/banner.png"></a>
 
@@ -6,24 +6,30 @@
 
 ## Project Description
 
-**Dodge Object Game** is a web-based browser game built **from scratch using vanilla JavaScript** (no external game frameworks).
+**Dodge Objects Game** is a web-based browser game built **from scratch using vanilla JavaScript** (no external game frameworks).
 
 This project is part of **IIEST, Shibpur's** **[Winter of Open Source](https://winter-of-open-source.vercel.app/)**, where contributors will:
+
 - Implement game mechanics using vanilla JavaScript
 - Understand game loops, collision detection, and DOM manipulation
 - Build a fully functional game without using any prebuilt game frameworks
 
 ### What You'll Build
 
-| Component | Current Status | What Needs To Be Done |
-|-----------|---------------|----------------------|
-| **Gameplay** | 🟢 Core mechanics working | Add power-ups, different obstacle types, difficulty levels |
-| **UI/UX** | 🟡 Basic interface | Improve animations, add sound effects, better visual feedback |
+| Component    | Current Status            | What Needs To Be Done                                         |
+| ------------ | ------------------------- | ------------------------------------------------------------- |
+| **Gameplay** | 🟢 Core mechanics working | Add power-ups, different obstacle types, difficulty levels    |
+| **UI/UX**    | 🟡 Basic interface        | Improve animations, add sound effects, better visual feedback |
+
+## Gameplay
+
+- **Start Game**: Press `Space`
+- **Move**: Use `←` `→` Arrow keys or `A` `D` keys
 
 ## Web Interface
 
 <p align="center">
-  <img src="assets/image.png" alt="Dodge Object Game Interface" width="1000">
+  <img src="assets/image.png" alt="Dodge Objects Game Interface" width="1000">
 </p>
 
 ---
@@ -40,7 +46,6 @@ This project is part of **IIEST, Shibpur's** **[Winter of Open Source](https://w
 ```
 
 > See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed setup instructions and guidelines.
-
 
 ## Communication
 


### PR DESCRIPTION
Closes #1

## Changes
- Corrected 'Dodge Object Game' to 'Dodge Objects Game' in title and description.
- Added 'Gameplay' section with control instructions.
- Fixed alt text for the interface image.